### PR TITLE
Fix for String for an MTSE, and other tweaks

### DIFF
--- a/doc/z-chap12.xml
+++ b/doc/z-chap12.xml
@@ -30,7 +30,7 @@
     For inverse semigroups these two conditions are equivalent. We are only
     interested in <E>E-unitary inverse semigroups</E>. 
     Before defining McAlister triple semigroups we define a McAlister triple.
-    A <E>McAlister triple</E> is a triple <C>(G,X,Y)</C> which consist of:
+    A <E>McAlister triple</E> is a triple <C>(G,X,Y)</C> which consists of:
 
     <List>
       <Item>

--- a/gap/semigroups/semieunit.gi
+++ b/gap/semigroups/semieunit.gi
@@ -200,7 +200,14 @@ function(S)
   X := McAlisterTripleSemigroupPartialOrder(S);
   Y := McAlisterTripleSemigroupSemilattice(S);
   return Concatenation("McAlisterTripleSemigroup(", String(G), ", ",
-                       String(X), ", ", String(Y), ")");
+                       String(X), ", ", String(DigraphVertexLabels(Y)), ")");
+end);
+
+InstallMethod(PrintObj, "for a McAlister triple semigroup",
+[IsMcAlisterTripleSemigroup],
+function(S)
+  Print(String(S));
+  return;
 end);
 
 #TODO Linebreak hints
@@ -309,10 +316,8 @@ end);
 InstallMethod(String, "for a McAlister triple semigroup element rep",
 [IsMcAlisterTripleSemigroupElementRep],
 function(x)
-  return Concatenation("MTSE(", String(x![3]), ", ",
-    String(DigraphVertexLabels(
-           McAlisterTripleSemigroupSemilattice(x![3]))[x[1]]),
-    ", ", String(x[2]), ")");
+  return Concatenation("MTSE(", String(x![3]), ", ", String(x![1]), ", ",
+                       String(x![2]), ")");
 end);
 
 #TODO Linebreak hints

--- a/tst/standard/semieunit.tst
+++ b/tst/standard/semieunit.tst
@@ -28,8 +28,10 @@ gap> M = McAlisterTripleSemigroup(G, x, [1, 2, 3, 4]);
 true
 gap> String(M);
 "McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ], [ 1,\
- 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), Digraph( [ [ 1 ], [ 1, 2 ], [ 1, 3 ], \
-[ 1, 4 ] ] ))"
+ 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ])"
+gap> Print(M, "\n");
+McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ], [ 1, \
+2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ])
 
 #T# McAlisterTripleSemigroup with bad inputs
 gap> G1 := FreeGroup(1);;
@@ -132,8 +134,7 @@ true
 gap> elms := Enumerator(M);;
 gap> String(elms[1]);
 "MTSE(McAlisterTripleSemigroup(SymmetricGroup( [ 2 .. 5 ] ), Digraph( [ [ 1 ],\
- [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), Digraph( [ [ 1 ], [ 1, 2 ], [ 1, \
-3 ], [ 1, 4 ] ] )), 1, ())"
+ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ] ] ), [ 1 .. 4 ]), 1, ())"
 gap> OneImmutable(M);
 Error, Semigroups: OneImutable (for McAlister triple semigroup): usage,
 the argument must be a monoid,
@@ -225,6 +226,18 @@ gap> M5 := McAlisterTripleSemigroup(G, x1, x1, act);;
 gap> IsomorphismSemigroups(M1, M5);
 fail
 
+#T# IsomorphismSemigroups, where RepresentativeAction fails
+gap> gr := DigraphFromDigraph6String("+H_A?GC_Q@G~wA?G");
+<digraph with 9 vertices, 20 edges>
+gap> G := Group((1, 2, 3)(4, 5, 6), (8, 9));
+Group([ (1,2,3)(4,5,6), (8,9) ])
+gap> S1 := McAlisterTripleSemigroup(G, gr, [1, 4, 5, 7, 8]);
+<McAlister triple semigroup over Group([ (1,2,3)(4,5,6), (8,9) ])>
+gap> S2 := McAlisterTripleSemigroup(G, gr, [3, 6, 7, 8, 9]);
+<McAlister triple semigroup over Group([ (1,2,3)(4,5,6), (8,9) ])>
+gap> IsomorphismSemigroups(S1, S2);
+fail
+
 #T# IsIsomorphicSemigroup
 gap> IsIsomorphicSemigroup(M1, M1);
 true
@@ -260,6 +273,11 @@ gap> IsFInverseMonoid(M);
 true
 gap> IsFInverseSemigroup(M);
 true
+gap> S := McAlisterTripleSemigroup(Group((4, 5)),
+> Digraph([[1], [1, 2], [1, 3], [1, 2, 3, 4], [1, 2, 3, 5]]), [1 .. 4]);
+<McAlister triple semigroup over Group([ (4,5) ])>
+gap> IsFInverseSemigroup(S);
+false
 
 #T# EUnitaryInverseCover
 gap> S := InverseMonoid([PartialPermNC([1, 3], [1, 3]),


### PR DESCRIPTION
Whilst doing my (hopefully) final review of your e-unitary pull request to the Semigroups package, I made a couple of changes since I thought that would be the best thing to do. It's mostly changes to the way that a MTS is shown using `String` or `Print`, as well as a tiny change to the doc, and a couple of new tests.